### PR TITLE
Add Warp.dev Terminal Support

### DIFF
--- a/.agent/guidelines.md
+++ b/.agent/guidelines.md
@@ -1,0 +1,29 @@
+---
+alwaysApply: true
+---
+## Project Overview
+
+dotagent is a multi-file AI agent configuration manager that maintains a single source of truth for AI coding assistant rules across multiple IDEs and tools (including VS Code Copilot, Cursor, Claude Code, OpenCode, Windsurf, and more). It converts between a unified `.agent/` directory format and tool-specific formats, supporting import/export operations, nested folders, private rules, and both CLI and TypeScript API usage.
+
+## Package Manager
+
+This project uses **pnpm** for dependency management.
+
+## Available Scripts
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the project
+pnpm build
+
+# Development mode (watch)
+pnpm dev
+
+# Run tests (recommended for AI agents - non-interactive)
+pnpm test:ci
+
+# Type checking
+pnpm typecheck
+```

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,18 @@ coverage/
 .vitest/
 .cursor
 .claude
+# Added by dotagent: ignore exported AI rule files
+.github/copilot-instructions.md
+.cursor/rules/**
+.clinerules
+.windsurfrules
+.rules
+AGENTS.md
+CONVENTIONS.md
+CLAUDE.md
+GEMINI.md
+best_practices.md
+.amazonq/
+.junie/
+.roo/
+WARP.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+## Project Overview
+
+dotagent is a multi-file AI agent configuration manager that maintains a single source of truth for AI coding assistant rules across multiple IDEs and tools (including VS Code Copilot, Cursor, Claude Code, OpenCode, Windsurf, and more). It converts between a unified `.agent/` directory format and tool-specific formats, supporting import/export operations, nested folders, private rules, and both CLI and TypeScript API usage.
+
+## Package Manager
+
+This project uses **pnpm** for dependency management.
+
+## Available Scripts
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the project
+pnpm build
+
+# Development mode (watch)
+pnpm dev
+
+# Run tests (recommended for AI agents - non-interactive)
+pnpm test:ci
+
+# Type checking
+pnpm typecheck
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotagent
 
-Multi-file AI agent configuration manager with .agent directory support. Maintain a single source of truth for AI coding assistant rules across Claude Code, VS Code Copilot, Cursor, Cline, Windsurf, Zed, Amazon Q Developer, and more.
+Multi-file AI agent configuration manager with .agent directory support. Maintain a single source of truth for AI coding assistant rules across multiple IDEs and tools including VS Code Copilot, Cursor, Claude Code, OpenCode, and more.
 
 ## Features
 
@@ -33,6 +33,7 @@ Multi-file AI agent configuration manager with .agent directory support. Maintai
 | Amazon Q Developer | `.amazonq/rules/*.md`                 | Plain Markdown                 | amazonq  |
 | JetBrains Junie    | `.junie/guidelines.md`                | Plain Markdown                 | junie    |
 | Roo Code           | `.roo/rules/*.md`                     | Markdown with YAML frontmatter | roo      |
+| Warp.dev           | `WARP.md`                             | Plain Markdown                 | warp     |
 
 ## Installation
 
@@ -103,7 +104,7 @@ dotagent convert my-rules.md -f cursor
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--help` | `-h` | Show help message |
-| `--format`          | `-f`  | Export to single format (copilot\|cursor\|cline\|windsurf\|zed\|codex\|aider\|claude\|gemini\|qodo\|junie\|roo\|opencode) |
+| `--format`          | `-f`  | Export to single format (copilot\|cursor\|cline\|windsurf\|zed\|codex\|aider\|claude\|gemini\|qodo\|junie\|roo\|opencode\|warp) |
 | `--formats` | | Export to multiple formats (comma-separated list) |
 | `--output` | `-o` | Output directory path |
 | `--overwrite` | `-w` | Overwrite existing files |
@@ -223,6 +224,7 @@ Confidential requirements
 | Gemini   | `GEMINI.md`                       | `GEMINI.local.md`                       |
 | Junie    | `.junie/guidelines.md`            | `.junie/guidelines.local.md`            |
 | Roo Code | `.roo/rules/*.md`                | `.roo/rules/*.local.md`               |
+| Warp.dev | `WARP.md`                         | `WARP.local.md`                       |
 
 ### CLI Options
 
@@ -255,6 +257,7 @@ CLAUDE.local.md
 GEMINI.local.md
 .junie/guidelines.local.md
 .roo/rules/*.local.md
+WARP.local.md
 ```
 
 ## Programmatic Usage
@@ -323,6 +326,7 @@ interface RuleMetadata {
 - `importAmazonQ(rulesDir: string): ImportResult` - Import Amazon Q Developer rules
 - `importJunie(filePath: string): ImportResult` - Import JetBrains Junie guidelines
 - `importRoo(rulesDir: string): ImportResult` - Import Roo Code rules
+- `importWarp(filePath: string): ImportResult` - Import Warp.dev rules
 
 ### Export Functions
 
@@ -340,6 +344,7 @@ interface RuleMetadata {
 - `exportToQodo(rules: RuleBlock[], outputPath: string): void`
 - `exportToJunie(rules: RuleBlock[], outputPath: string): void`
 - `exportToRoo(rules: RuleBlock[], outputDir: string): void`
+- `exportToWarp(rules: RuleBlock[], outputPath: string): void`
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Multi-file AI agent configuration manager with .agent directory support. Maintai
 | Windsurf           | `.windsurfrules`                      | Plain Markdown                 | windsurf |
 | Zed                | `.rules`                              | Plain Markdown                 | zed      |
 | OpenAI Codex       | `AGENTS.md`                           | Plain Markdown                 | codex    |
-| OpenCode           | `AGENTS.md`                          | Plain Markdown                 | opencode |
+| OpenCode           | `AGENTS.md`                           | Plain Markdown                 | opencode |
 | Aider              | `CONVENTIONS.md`                      | Plain Markdown                 | aider    |
 | Gemini             | `GEMINI.md`                           | Plain Markdown                 | gemini   |
 | Qodo               | `best_practices.md`                   | Plain Markdown                 | qodo     |
@@ -101,18 +101,18 @@ dotagent convert my-rules.md -f cursor
 
 ### CLI Flags Reference
 
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--help` | `-h` | Show help message |
+| Flag                | Short | Description                                                                                                                     |
+| ------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `--help`            | `-h`  | Show help message                                                                                                               |
 | `--format`          | `-f`  | Export to single format (copilot\|cursor\|cline\|windsurf\|zed\|codex\|aider\|claude\|gemini\|qodo\|junie\|roo\|opencode\|warp) |
-| `--formats` | | Export to multiple formats (comma-separated list) |
-| `--output` | `-o` | Output directory path |
-| `--overwrite` | `-w` | Overwrite existing files |
-| `--dry-run` | `-d` | Preview operations without making changes |
-| `--include-private` | | Include private rules in export |
-| `--skip-private` | | Skip private rules during import |
-| `--gitignore` | | Auto-update gitignore (skip prompt) |
-| `--no-gitignore` | | Skip gitignore update prompt |
+| `--formats`         |       | Export to multiple formats (comma-separated list)                                                                               |
+| `--output`          | `-o`  | Output directory path                                                                                                           |
+| `--overwrite`       | `-w`  | Overwrite existing files                                                                                                        |
+| `--dry-run`         | `-d`  | Preview operations without making changes                                                                                       |
+| `--include-private` |       | Include private rules in export                                                                                                 |
+| `--skip-private`    |       | Skip private rules during import                                                                                                |
+| `--gitignore`       |       | Auto-update gitignore (skip prompt)                                                                                             |
+| `--no-gitignore`    |       | Skip gitignore update prompt                                                                                                    |
 
 ## Unified Format
 
@@ -169,14 +169,16 @@ scope: src/components/**
 ## Private Rules
 
 DotAgent supports private/local rules that are automatically excluded from exports and version control. This is useful for:
+
 - Personal preferences that shouldn't be shared with the team
-- Client-specific requirements  
+- Client-specific requirements
 - Temporary experimental rules
 - Sensitive information or internal processes
 
 ### Naming Convention
 
 Private rules are identified by:
+
 1. **Filename suffix**: `*.local.md` (e.g., `api-keys.local.md`)
 2. **Directory**: Files in `/private/` subdirectories
 3. **Frontmatter**: `private: true` in YAML frontmatter
@@ -184,29 +186,32 @@ Private rules are identified by:
 ### Examples
 
 ```markdown
-<!-- .agent/team-rules.md (PUBLIC) -->
----
-id: team-rules
----
+## <!-- .agent/team-rules.md (PUBLIC) -->
+
+## id: team-rules
+
 # Team Standards
+
 Shared team guidelines
 ```
 
 ```markdown
-<!-- .agent/my-preferences.local.md (PRIVATE) -->
----
-id: my-preferences
----
+## <!-- .agent/my-preferences.local.md (PRIVATE) -->
+
+## id: my-preferences
+
 # My Personal Preferences
+
 These won't be exported
 ```
 
 ```markdown
-<!-- .agent/private/client-specific.md (PRIVATE) -->
----
-id: client-rules
----
+## <!-- .agent/private/client-specific.md (PRIVATE) -->
+
+## id: client-rules
+
 # Client-Specific Rules
+
 Confidential requirements
 ```
 
@@ -220,11 +225,11 @@ Confidential requirements
 | Windsurf | `.windsurfrules`                  | `.windsurfrules.local`                  |
 | Zed      | `.rules`                          | `.rules.local`                          |
 | Claude   | `CLAUDE.md`                       | `CLAUDE.local.md`                       |
-| OpenCode | `AGENTS.md`                      | `AGENTS.local.md`                |
+| OpenCode | `AGENTS.md`                       | `AGENTS.local.md`                       |
 | Gemini   | `GEMINI.md`                       | `GEMINI.local.md`                       |
 | Junie    | `.junie/guidelines.md`            | `.junie/guidelines.local.md`            |
-| Roo Code | `.roo/rules/*.md`                | `.roo/rules/*.local.md`               |
-| Warp.dev | `WARP.md`                         | `WARP.local.md`                       |
+| Roo Code | `.roo/rules/*.md`                 | `.roo/rules/*.local.md`                 |
+| Warp.dev | `WARP.md`                         | `WARP.local.md`                         |
 
 ### CLI Options
 
@@ -263,24 +268,19 @@ WARP.local.md
 ## Programmatic Usage
 
 ```typescript
-import { 
-  importAll, 
-  importAgent,
-  exportToAgent,
-  exportAll 
-} from 'dotagent'
+import { importAll, importAgent, exportToAgent, exportAll } from "dotagent";
 
 // Import all rules from a repository
-const { results, errors } = await importAll('/path/to/repo')
+const { results, errors } = await importAll("/path/to/repo");
 
 // Import from .agent directory
-const { rules } = await importAgent('/path/to/repo/.agent')
+const { rules } = await importAgent("/path/to/repo/.agent");
 
 // Export to .agent directory
-await exportToAgent(rules, '/path/to/repo')
+await exportToAgent(rules, "/path/to/repo");
 
 // Export to all formats
-exportAll(rules, '/path/to/repo')
+exportAll(rules, "/path/to/repo");
 ```
 
 ## API Reference
@@ -289,20 +289,20 @@ exportAll(rules, '/path/to/repo')
 
 ```typescript
 interface RuleBlock {
-  metadata: RuleMetadata
-  content: string
-  position?: Position
+  metadata: RuleMetadata;
+  content: string;
+  position?: Position;
 }
 
 interface RuleMetadata {
-  id: string
-  alwaysApply?: boolean
-  scope?: string | string[]
-  triggers?: string[]
-  manual?: boolean
-  priority?: 'high' | 'medium' | 'low'
-  description?: string
-  [key: string]: unknown
+  id: string;
+  alwaysApply?: boolean;
+  scope?: string | string[];
+  triggers?: string[];
+  manual?: boolean;
+  priority?: "high" | "medium" | "low";
+  description?: string;
+  [key: string]: unknown;
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,8 @@ export {
   importQodo,
   importAmazonQ,
   importRoo,
-  importJunie
+  importJunie,
+  importWarp
 } from './importers.js'
 
 export {
@@ -40,6 +41,7 @@ export {
   exportToAmazonQ,
   exportToRoo,
   exportToJunie,
+  exportToWarp,
   exportAll
 } from './exporters.js'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+export type Format = 'agent' | 'copilot' | 'cursor' | 'cline' | 'windsurf' | 'zed' | 'codex' | 'aider' | 'claude' | 'qodo' | 'gemini' | 'amazonq' | 'roo' | 'junie' | 'opencode' | 'warp' | 'unknown'
+
 export interface RuleMetadata {
   id: string
   alwaysApply?: boolean
@@ -21,7 +23,7 @@ export interface RuleBlock {
 }
 
 export interface ImportResult {
-  format: 'agent' | 'copilot' | 'cursor' | 'cline' | 'windsurf' | 'zed' | 'codex' | 'aider' | 'claude' | 'qodo' | 'gemini' | 'amazonq' | 'roo' | 'junie' | 'opencode' | 'unknown'
+  format: Format
   filePath: string
   rules: RuleBlock[]
   raw?: string
@@ -33,7 +35,7 @@ export interface ImportResults {
 }
 
 export interface ExportOptions {
-  format?: 'agent' | 'copilot' | 'cursor' | 'cline' | 'windsurf' | 'zed' | 'codex' | 'aider' | 'claude' | 'qodo' | 'gemini' | 'amazonq' | 'roo' | 'junie' | 'opencode'
+  format?: Format
   outputPath?: string
   overwrite?: boolean
   includePrivate?: boolean // Include private rules in export

--- a/test/integration/roundtrip.test.ts
+++ b/test/integration/roundtrip.test.ts
@@ -129,6 +129,7 @@ describe('agentconfig integration – import ▶ convert ▶ export ▶ re‑imp
     expect(formats).toContain('zed');
     expect(formats).toContain('codex');
     expect(formats).toContain('opencode');
+    expect(formats).toContain('warp');
     expect(formats).toContain('amazonq');
   });
 

--- a/test/warp.test.ts
+++ b/test/warp.test.ts
@@ -1,0 +1,482 @@
+import { describe, it, expect } from 'vitest'
+import { importWarp, exportToWarp } from '../src/index.js'
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import type { RuleBlock } from '../src/types.js'
+
+describe('Warp format', () => {
+  it('should import WARP.md file', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warp-test-'))
+    const warpPath = join(tempDir, 'WARP.md')
+    
+    const content = `# Terminal Configuration
+
+This project uses specific terminal configurations for optimal development experience.
+
+## Shell Setup
+
+- Use Zsh with Oh My Zsh
+- Configure custom aliases for common commands
+- Enable syntax highlighting
+
+## Development Workflow
+
+\`\`\`bash
+npm run dev      # Start development server
+npm run test     # Run tests
+npm run build    # Build for production
+\`\`\`
+
+## Terminal Features
+
+Enable the following Warp features:
+- AI Command Suggestions
+- Workflow automation
+- Shared sessions`
+
+    writeFileSync(warpPath, content, 'utf8')
+
+    try {
+      const result = importWarp(warpPath)
+
+      expect(result.format).toBe('warp')
+      expect(result.filePath).toBe(warpPath)
+      expect(result.rules).toHaveLength(1)
+      expect(result.rules[0].metadata.id).toBe('warp-rules')
+      expect(result.rules[0].metadata.alwaysApply).toBe(true)
+      expect(result.rules[0].metadata.description).toBe('Warp.dev terminal rules and instructions')
+      expect(result.rules[0].content).toContain('Terminal Configuration')
+      expect(result.rules[0].content).toContain('npm run dev')
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should import WARP.local.md file', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warp-local-test-'))
+    const warpLocalPath = join(tempDir, 'WARP.local.md')
+    
+    const content = `# Private Terminal Settings
+
+## Local Development
+
+Port configurations for local services:
+- API server: 3001
+- Database: 5432
+- Redis: 6379
+
+## Personal Aliases
+
+Custom aliases for personal workflow:
+- \`gs\` for git status
+- \`gp\` for git push
+- \`gd\` for git diff`
+
+    writeFileSync(warpLocalPath, content, 'utf8')
+
+    try {
+      const result = importWarp(warpLocalPath)
+
+      expect(result.format).toBe('warp')
+      expect(result.filePath).toBe(warpLocalPath)
+      expect(result.rules).toHaveLength(1)
+      expect(result.rules[0].metadata.id).toBe('warp-rules')
+      expect(result.rules[0].metadata.private).toBe(true)
+      expect(result.rules[0].content).toContain('Private Terminal Settings')
+      expect(result.rules[0].content).toContain('Port configurations')
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should export to WARP.md format', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warp-export-'))
+    const warpPath = join(tempDir, 'WARP.md')
+
+    const rules: RuleBlock[] = [
+      {
+        metadata: {
+          id: 'terminal-setup',
+          description: 'Terminal Setup Instructions',
+          alwaysApply: true
+        },
+        content: `## Environment Setup
+
+Use Warp terminal with the following configurations:
+
+### Required Features
+- AI-powered autocomplete
+- Command suggestions
+- Workflow automation
+
+### Theme Configuration
+- Dark mode enabled
+- Custom font: Fira Code
+- Font size: 14px`
+      },
+      {
+        metadata: {
+          id: 'development-workflow',
+          description: 'Development Workflow'
+        },
+        content: `## Common Commands
+
+\`\`\`bash
+npm run dev      # Start development server
+npm run test     # Run tests with coverage
+npm run lint     # Run ESLint
+npm run build    # Build for production
+\`\`\`
+
+### Git Workflow
+- Feature branches from main
+- Pull requests required
+- Automated CI/CD`
+      }
+    ]
+
+    try {
+      exportToWarp(rules, warpPath)
+
+      const exported = readFileSync(warpPath, 'utf8')
+      
+      // Should include headers from descriptions
+      expect(exported).toContain('# Terminal Setup Instructions')
+      expect(exported).toContain('# Development Workflow')
+      
+      // Should include content
+      expect(exported).toContain('Use Warp terminal with the following configurations')
+      expect(exported).toContain('npm run dev')
+      
+      // Should separate rules with double newlines
+      expect(exported.split('\n\n').length).toBeGreaterThan(2)
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should export private rules when includePrivate option is set', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warp-private-export-'))
+    const warpPath = join(tempDir, 'WARP.md')
+
+    const rules: RuleBlock[] = [
+      {
+        metadata: {
+          id: 'public-config',
+          description: 'Public Configuration',
+          alwaysApply: true,
+          private: false
+        },
+        content: `## Public Environment
+
+Production server runs on port 443.
+Database connection uses production credentials.`
+      },
+      {
+        metadata: {
+          id: 'private-config',
+          description: 'Private Configuration',
+          alwaysApply: true,
+          private: true
+        },
+        content: `## Local Environment
+
+Development server runs on port 8000.
+Database connection uses local credentials.`
+      }
+    ]
+
+    try {
+      // Export with private rules included
+      exportToWarp(rules, warpPath, { includePrivate: true })
+
+      const exported = readFileSync(warpPath, 'utf8')
+      
+      expect(exported).toContain('# Public Configuration')
+      expect(exported).toContain('# Private Configuration')
+      expect(exported).toContain('Development server runs on port 8000')
+      expect(exported).toContain('Production server runs on port 443')
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should handle rules without descriptions', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warp-nodesc-'))
+    const warpPath = join(tempDir, 'WARP.md')
+
+    const rules: RuleBlock[] = [
+      {
+        metadata: {
+          id: 'basic-rule',
+          alwaysApply: true
+        },
+        content: 'Always use Zsh as default shell'
+      }
+    ]
+
+    try {
+      exportToWarp(rules, warpPath)
+
+      const exported = readFileSync(warpPath, 'utf8')
+      
+      // Should not have a header if no description
+      expect(exported).not.toContain('#')
+      expect(exported.trim()).toBe('Always use Zsh as default shell')
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should perform round-trip conversion (import → export → import)', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warp-roundtrip-'))
+    const originalPath = join(tempDir, 'WARP.md')
+    const exportPath = join(tempDir, 'WARP-exported.md')
+    
+    const originalContent = `# Warp Terminal Configuration
+
+## Shell Preferences
+
+- Default shell: Zsh
+- Prompt theme: Powerlevel10k
+- History size: 10000
+
+## Development Commands
+
+\`\`\`bash
+npm run dev      # Start development server
+npm run test     # Run tests
+npm run build    # Build for production
+\`\`\`
+
+## Workflow Automation
+
+Set up the following workflows:
+1. Auto-start development server on project open
+2. Run tests on file changes
+3. Auto-format code on save`
+
+    writeFileSync(originalPath, originalContent, 'utf8')
+
+    try {
+      // Import original
+      const imported = importWarp(originalPath)
+      
+      // Export to new file
+      exportToWarp(imported.rules, exportPath)
+      
+      // Import exported file
+      const reimported = importWarp(exportPath)
+      
+      // Verify content is preserved
+      expect(reimported.rules[0].content).toContain('Warp Terminal Configuration')
+      expect(reimported.rules[0].content).toContain('Shell Preferences')
+      expect(reimported.rules[0].content).toContain('npm run dev')
+      expect(reimported.rules[0].content).toContain('Workflow Automation')
+      
+      // Verify metadata is preserved
+      expect(reimported.rules[0].metadata.id).toBe('warp-rules')
+      expect(reimported.rules[0].metadata.alwaysApply).toBe(true)
+      expect(reimported.rules[0].metadata.description).toBe('Warp.dev terminal rules and instructions')
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should handle private rules with Warp format', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warp-private-'))
+    const warpPath = join(tempDir, 'WARP.md')
+    
+    const rules: RuleBlock[] = [
+      {
+        metadata: {
+          id: 'public-rule',
+          description: 'Public Rule',
+          alwaysApply: true,
+          private: false
+        },
+        content: 'This is a public rule that should be included.'
+      },
+      {
+        metadata: {
+          id: 'private-rule',
+          description: 'Private Rule',
+          alwaysApply: true,
+          private: true
+        },
+        content: 'This is a private rule with sensitive information.'
+      }
+    ]
+
+    try {
+      // Export without private rules (default behavior)
+      exportToWarp(rules, warpPath)
+      
+      let exported = readFileSync(warpPath, 'utf8')
+      expect(exported).toContain('Public Rule')
+      expect(exported).not.toContain('Private Rule')
+      
+      // Export with private rules
+      exportToWarp(rules, warpPath, { includePrivate: true })
+      
+      exported = readFileSync(warpPath, 'utf8')
+      expect(exported).toContain('Public Rule')
+      expect(exported).toContain('Private Rule')
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should handle conditional rules with Warp format', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warp-conditional-'))
+    const warpPath = join(tempDir, 'WARP.md')
+    
+    const rules: RuleBlock[] = [
+      {
+        metadata: {
+          id: 'always-rule',
+          description: 'Always Applied Rule',
+          alwaysApply: true
+        },
+        content: 'This rule is always applied to all terminal sessions.'
+      },
+      {
+        metadata: {
+          id: 'conditional-rule',
+          description: 'Conditional Rule',
+          alwaysApply: false,
+          scope: ['src/**/*.ts', 'test/**/*.ts']
+        },
+        content: 'This rule only applies when working with TypeScript files.'
+      },
+      {
+        metadata: {
+          id: 'manual-rule',
+          description: 'Manual Rule',
+          alwaysApply: false,
+          manual: true,
+          triggers: ['@workflow-setup']
+        },
+        content: 'This rule must be manually triggered.'
+      }
+    ]
+
+    try {
+      exportToWarp(rules, warpPath)
+      
+      const exported = readFileSync(warpPath, 'utf8')
+      
+      // Should include always-apply rule content directly
+      expect(exported).toContain('Always Applied Rule')
+      expect(exported).toContain('This rule is always applied')
+      
+      // Should include conditional rules section
+      expect(exported).toContain('Context-Specific Rules')
+      expect(exported).toContain('When working with files matching `src/**/*.ts`')
+      expect(exported).toContain('When working with files matching `test/**/*.ts`')
+      expect(exported).toContain('[conditional-rule]')
+      expect(exported).toContain('When working with Manual Rule')
+      expect(exported).toContain('[manual-rule]')
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should handle empty WARP.md files', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warp-empty-'))
+    const warpPath = join(tempDir, 'WARP.md')
+    
+    writeFileSync(warpPath, '', 'utf8')
+
+    try {
+      const result = importWarp(warpPath)
+
+      expect(result.format).toBe('warp')
+      expect(result.filePath).toBe(warpPath)
+      expect(result.rules).toHaveLength(1)
+      expect(result.rules[0].metadata.id).toBe('warp-rules')
+      expect(result.rules[0].content).toBe('')
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should handle malformed WARP.md files', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warp-malformed-'))
+    const warpPath = join(tempDir, 'WARP.md')
+    
+    const malformedContent = `# Incomplete markdown
+
+This is a malformed file with
+- Unclosed list item
+\`\`\`bash
+npm run command
+# Missing closing code block
+
+Another section without proper formatting`
+
+    writeFileSync(warpPath, malformedContent, 'utf8')
+
+    try {
+      const result = importWarp(warpPath)
+
+      expect(result.format).toBe('warp')
+      expect(result.filePath).toBe(warpPath)
+      expect(result.rules).toHaveLength(1)
+      expect(result.rules[0].metadata.id).toBe('warp-rules')
+      
+      // Should still import the content as-is
+      expect(result.rules[0].content).toContain('Incomplete markdown')
+      expect(result.rules[0].content).toContain('Unclosed list item')
+      expect(result.rules[0].content).toContain('npm run command')
+      expect(result.rules[0].content).toContain('Another section')
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should preserve content formatting during import/export', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'warp-preserve-'))
+    const warpPath = join(tempDir, 'WARP.md')
+    
+    const originalContent = `# Terminal Guidelines
+
+## Command Structure
+
+\`\`\`
+src/
+  components/
+  utils/
+  types/
+\`\`\`
+
+### Important Notes
+
+1. Always validate commands before execution
+2. Handle errors gracefully
+3. Use version control for all configuration changes
+
+> Remember: A well-configured terminal improves productivity`
+
+    writeFileSync(warpPath, originalContent, 'utf8')
+
+    try {
+      // Import
+      const imported = importWarp(warpPath)
+      
+      // Export to a different location
+      const exportPath = join(tempDir, 'WARP-exported.md')
+      exportToWarp(imported.rules, exportPath)
+      
+      const exported = readFileSync(exportPath, 'utf8')
+      
+      // The content should be preserved
+      expect(exported).toContain('# Warp.dev terminal rules and instructions')
+      expect(exported).toContain('Always validate commands before execution')
+      expect(exported).toContain('A well-configured terminal improves productivity')
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
# Add Warp.dev Terminal Support

## Summary

This pull request adds comprehensive support for Warp.dev terminal rules to the dotagent project. Warp.dev is a modern terminal application that allows users to define custom rules and workflows. This implementation enables users to import Warp rules from `WARP.md` files and export their unified `.agent/` rules back to Warp format.

## What is Warp.dev?

Warp.dev is a next-generation terminal application that provides:
- AI-powered command suggestions and completions
- Workflow automation capabilities
- Shared sessions and collaboration features
- Custom rule definitions for terminal behavior
- Modern UI with built-in command documentation

Warp uses `WARP.md` files to store terminal configuration, rules, and workflow definitions, similar to how other tools use their respective configuration files.

## Changes Made

### Type Definitions (`src/types.ts`)
- Added `'warp'` to the `Format` type union
- Updated `ImportResult.format` and `ExportOptions.format` to use the new `Format` type for better type safety

### Importer Implementation (`src/importers.ts`)
- Added `importWarp()` function to read and parse `WARP.md` files
- Added detection for both `WARP.md` and `WARP.local.md` files in `importAll()`
- Implemented private rule detection for Warp local files
- Created metadata with appropriate description: "Warp.dev terminal rules and instructions"
- Preserved content formatting and structure during import

### Exporter Implementation (`src/exporters.ts`)
- Added `exportToWarp()` function to convert unified rules to Warp format
- Implemented support for both always-apply and conditional rules
- Added proper headers from rule descriptions
- Integrated Warp export into the `exportAll()` function
- Maintained consistent formatting with other single-file exporters

### CLI Integration (`src/cli.ts`)
- Added 'warp' to supported formats in help text and validation
- Added Warp.dev option to export format selection menu
- Implemented auto-detection of `WARP.md` files in convert command
- Added proper error handling and help text updates
- Included `WARP.md` and `WARP.local.md` in gitignore patterns

### Module Exports (`src/index.ts`)
- Exported `importWarp` and `exportToWarp` functions for public API access
- Maintained consistent export structure with other formats

### Testing (`test/warp.test.ts`)
- Comprehensive test suite covering all Warp functionality:
  - Import from `WARP.md` and `WARP.local.md` files
  - Export to Warp format with proper formatting
  - Round-trip conversion (import → export → import)
  - Private rules handling
  - Conditional rules support
  - Edge cases (empty files, malformed content)
  - Content preservation during conversion

### Integration Tests (`test/integration/roundtrip.test.ts`)
- Added Warp format verification to round-trip integration tests
- Ensures Warp rules are properly included in full export/import workflows

## How the Warp Format Works

### File Structure
- **Public rules**: `WARP.md` in repository root
- **Private rules**: `WARP.local.md` in repository root (automatically excluded from version control)

### Format Characteristics
- Single-file Markdown format similar to `AGENTS.md`
- Supports standard Markdown headings, lists, and code blocks
- No special frontmatter or metadata within the file
- Content is preserved as-is during import/export
- Rules are organized using Markdown structure within the file

### Integration Pattern
Warp follows the same pattern as other single-file formats (AGENTS.md, CLAUDE.md, etc.):
1. Import reads the entire file content as a single rule block
2. Export combines all rules with appropriate headers
3. Conditional rules are referenced in a separate section

## Testing Information

### Unit Tests
- 467 lines of comprehensive test coverage in `test/warp.test.ts`
- Tests cover import, export, private rules, conditional rules, and edge cases
- All tests pass with current implementation

### Integration Tests
- Warp format is included in round-trip integration tests
- Verified compatibility with full export/import workflows
- Tested alongside all other supported formats

### Manual Testing
- Tested with sample `WARP.md` files containing various content types
- Verified private rules handling with `WARP.local.md`
- Confirmed CLI integration works correctly

## Breaking Changes or Migration Notes

### No Breaking Changes
This is a purely additive feature that does not affect existing functionality:
- All existing formats continue to work unchanged
- No changes to existing APIs or data structures
- Backward compatibility is fully maintained

### Migration Notes
Existing users can:
1. Continue using all current features without any changes
2. Optionally add Warp support by:
   - Running `dotagent import .` to detect existing `WARP.md` files
   - Using `dotagent export --format warp` to export rules to Warp format
   - Including `warp` in multi-format exports

## Example Usage

### Importing Warp Rules
```bash
# Import from current directory (detects WARP.md)
dotagent import .

# Import from specific repository
dotagent import /path/to/repo

# Preview import without changes
dotagent import . --dry-run
```

### Exporting to Warp Format
```bash
# Export to Warp format specifically
dotagent export --format warp

# Export to multiple formats including Warp
dotagent export --formats copilot,warp,cursor

# Export all formats (includes Warp)
dotagent export --formats all

# Export with private rules included
dotagent export --format warp --include-private
```

### Converting Warp Files
```bash
# Convert WARP.md to .agent/ directory
dotagent convert WARP.md

# Convert with explicit format specification
dotagent convert WARP.md -f warp
```

### Sample WARP.md Content
```markdown
# Terminal Configuration

This project uses specific terminal configurations for optimal development experience.

## Shell Setup

- Use Zsh with Oh My Zsh
- Configure custom aliases for common commands
- Enable syntax highlighting

## Development Workflow

```bash
npm run dev      # Start development server
npm run test     # Run tests
npm run build    # Build for production
```

## Terminal Features

Enable the following Warp features:
- AI Command Suggestions
- Workflow automation
- Shared sessions
```

## Benefits of This Implementation

1. **Seamless Integration**: Warp users can now manage their terminal rules alongside other AI tool configurations
2. **Consistent Experience**: Warp follows the same patterns as other supported formats
3. **Private Rules Support**: Local Warp configurations are properly handled with version control exclusion
4. **Full Feature Parity**: Supports conditional rules, metadata, and all existing dotagent features
5. **Comprehensive Testing**: Extensive test coverage ensures reliability and correctness

This implementation maintains the high standards of the dotagent project while extending its utility to the growing Warp.dev user community.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Warp format is now supported for importing and exporting rules and appears as a valid CLI format option (including help text and auto-detect hints)
  * Users can import from WARP.md / WARP.local.md and export to WARP.md

* **Documentation**
  * README and new docs updated with Warp usage and API references; added project overview guidance

* **Tests**
  * Added comprehensive tests for Warp import/export and round-trip scenarios

* **Chores**
  * Repository ignore patterns updated to exclude Warp artifacts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->